### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ nose
 pytest
 python-hostlist
 simplejson
-ruamel.yaml
+ruamel.yaml<0.15
 colorama
 psutil
 tox

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ nose
 pytest
 hypothesis
 simplejson
-ruamel.yaml
+ruamel.yaml<0.15
 colorama
 psutil
 tox


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your user could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.
