### PR TITLE
Update `ruamel.yaml` package for python 3.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,8 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# IDE
+.vs/
+.idea/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+.noseids
 htmlcov/
 .tox/
 .coverage

--- a/cloudmesh/common/ssh/ssh_config.py
+++ b/cloudmesh/common/ssh/ssh_config.py
@@ -7,8 +7,7 @@ import json
 import os
 from textwrap import dedent
 
-from cloudmesh.shell.console import Console
-
+from cloudmesh.common.console import Console
 from cloudmesh.common.Shell import Shell
 
 

--- a/cloudmesh/common/util.py
+++ b/cloudmesh/common/util.py
@@ -94,7 +94,7 @@ def path_expand(text):
     """
     result = os.path.expanduser(text)
 
-    # os.path.expandvars(path)¶
+    # os.path.expandvars(path)
 
     # template = Template(text)
     # result = template.substitute(os.environ)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ nose
 pytest
 python-hostlist
 simplejson
-ruamel.yaml<0.15
+ruamel.yaml==0.15.71
 colorama
 psutil
 tox

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ def readfile(filename):
     with io.open(filename, encoding="utf-8") as stream:
         return stream.read()
 
-
 # requiers = readfile ('requirements.txt')
 
 # pytz==2016.10
@@ -35,7 +34,7 @@ future
 prettytable
 python-hostlist
 simplejson
-ruamel.yaml<0.15
+ruamel.yaml==0.15.71
 colorama
 psutil
 hypothesis

--- a/tests/cm_basic/test_configdict.py
+++ b/tests/cm_basic/test_configdict.py
@@ -12,7 +12,6 @@ nosetests -v tests/cm_basic/test_configdict.py
 from __future__ import print_function
 
 import os
-import shutil
 
 from cloudmesh.common.ConfigDict import ConfigDict
 from cloudmesh.common.util import HEADING

--- a/tests/cm_basic/test_shell.py
+++ b/tests/cm_basic/test_shell.py
@@ -38,4 +38,4 @@ class Test_shell(object):
         HEADING("check if we can run help:return: ")
         r = run("whoami")
         print(r)
-        assert getpass.getuser() == r
+        assert getpass.getuser() in r

--- a/tests/cm_basic/test_strdb.py
+++ b/tests/cm_basic/test_strdb.py
@@ -3,15 +3,17 @@
 
 #
 # TODO: theres is absolutely no need to use hypothesis. THis code does not
-#       follow our convention to develop nose tests. Also usining nosetests allows us
-#       to get rid of hypothesis
+#       follow our convention to develop nose tests. Also using nosetests 
+#       allows us to get rid of hypothesis
 #
+import os
 import unittest
 from hypothesis import given
 from hypothesis import strategies as st
 from tempfile import mkstemp
+from ruamel import yaml
+from cloudmesh.db.strdb import YamlDB
 
-# TODO strdb import missing
 
 class TestYamlDB(unittest.TestCase):
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py37
 [testenv]
 deps = -rrequirements.txt
 commands=py.test -v


### PR DESCRIPTION
Currently, trying to install [cloudmesh.common](https://pypi.org/project/cloudmesh.common/) in a python 3.7 environment fails do to a [ruamel.yaml<0.15 incompatibility discussed here](https://bitbucket.org/ruamel/yaml/issues/207/0412-fails-to-install-with-python-37). 

In the discussion the ruamel.yaml maintainer suggests that he has so far made only non-API-breaking changes to the >0.15 versions. 

To test the safety of this upgrade, I had to fix a couple of small things such as imports being missing or incorrect. Verified that tests run in 2.7 and 3.7.