### PR TITLE
Config encryption

### DIFF
--- a/cloudmesh/common/util.py
+++ b/cloudmesh/common/util.py
@@ -345,15 +345,19 @@ def copy_files(files_glob, source_dir, dest_dir):
             shutil.copy2(filename, dest_dir)
 
 
-def readfile(filename):
+def readfile(filename, mode='r'):
     """
     returns the content of a file
     :param filename: the filename
     :return: 
     """
-    with open(path_expand(filename), 'r') as f:
-        content = f.read()
-    return content
+    if mode != 'r' and mode != 'rb':
+        Console.error( f"incorrect mode : expected \'r\' or \'rb\' given {mode}\n")
+    else:
+        with open(path_expand(filename), mode)as f:
+            content = f.read()
+            f.close()
+        return content
 
 
 def writefile(filename, content):

--- a/cloudmesh/common/util.py
+++ b/cloudmesh/common/util.py
@@ -370,6 +370,21 @@ def writefile(filename, content):
     with open(path_expand(filename), 'w') as outfile:
         outfile.write(content)
 
+def writefd(filename, content, mode='w', flags = os.O_RDWR|os.O_CREAT, mask=0o600):
+    """
+    writes the content into the file and control permissions
+    :param filename: the full or relative path to the filename
+    :param content: the content being written
+    :param mode: the write mode ('w') or write bytes mode ('wb')
+    :param flags: the os flags that determine the permissions for the file
+    :param mask: the mask that the permissions will be applied to
+    """
+    if mode != 'w' and mode != 'wb':
+        Console.error( f"incorrect mode : expected \'w\' or \'wb\' given {mode}\n")
+
+    with os.fdopen(os.open(filename, flags, mask), mode) as outfile:
+        outfile.write(content)
+        outfile.close()
 
 # Reference: http://interactivepython.org/runestone/static/everyday/2013/01/3_password.html
 def generate_password(length=8, lower=True, upper=True, number=True):


### PR DESCRIPTION
To enable config encryption this PR should be accepted with the other PRs for cloud and configuration. 

This PR makes one minor change and introduces one function. 
1) readfile() introduces one argument to dictate the mode the file is opened in. Specifically it only accepts 'r' and 'rb' modes. The 'rb' mode is used to read either key or cipher files bytes by the CmsEncryptor or CmsKeyLoader classes (introduced in cloud PR). Since the default mode is 'r' none of the previous functions that called readfile() need to be changed. 

2) writefd() is introduced to allow finer control on file permissions when a file is written. 
This allows cloudmesh to restrict access to particular files. Namely, the key and nonce files stored by the CmsEncryptor class. Instead of allowing all users read or write access it can fine tune the acces. For encryption all files are restricted to read/write only access for the user that wrote the file. 

For more details please reference this [report.md](https://github.com/cloudmesh-community/fa19-516-144/blob/master/project/report.md). 