### PR TITLE
Correct WindowsNotImplemented Decorator in Shell

### DIFF
--- a/cloudmesh/common/Shell.py
+++ b/cloudmesh/common/Shell.py
@@ -25,15 +25,13 @@ import stat
 from pathlib import Path
 
 def NotImplementedInWindows(f):
-    def arg_catcher(*args):
-        def new_f():
-            if sys.platfom == "win32":
-                Console.error("The method {f.__name__} is not implemented in Windows,"
-                            " please implement, and/or submit an issue.")
-                sys.exit()
-            f(args)
-        return new_f
-    return arg_catcher
+    def new_f(*args):
+        if sys.platfom == "win32":
+            Console.error("The method {f.__name__} is not implemented in Windows,"
+                        " please implement, and/or submit an issue.")
+            sys.exit()
+        f(args)
+    return new_f
 
 
 

--- a/cloudmesh/common/Shell.py
+++ b/cloudmesh/common/Shell.py
@@ -31,7 +31,7 @@ def NotImplementedInWindows(f):
                 Console.error("The method {f.__name__} is not implemented in Windows,"
                             " please implement, and/or submit an issue.")
                 sys.exit()
-            f()
+            f(args)
         return new_f
     return arg_catcher
 

--- a/cloudmesh/common/Shell.py
+++ b/cloudmesh/common/Shell.py
@@ -25,13 +25,15 @@ import stat
 from pathlib import Path
 
 def NotImplementedInWindows(f):
-    def new_f():
-        if sys.platfom == "win32":
-            Console.error("The method {f.__name__} is not implemented in Windows,"
-                          " please implement, and/or submit an issue.")
-            sys.exit()
-        f()
-    return new_f
+    def arg_catcher(*args):
+        def new_f():
+            if sys.platfom == "win32":
+                Console.error("The method {f.__name__} is not implemented in Windows,"
+                            " please implement, and/or submit an issue.")
+                sys.exit()
+            f()
+        return new_f
+    return arg_catcher
 
 
 

--- a/cloudmesh/common/Shell.py
+++ b/cloudmesh/common/Shell.py
@@ -25,13 +25,15 @@ import stat
 from pathlib import Path
 
 def NotImplementedInWindows(f):
-    def new_f(*args):
-        if sys.platfom == "win32":
-            Console.error("The method {f.__name__} is not implemented in Windows,"
-                        " please implement, and/or submit an issue.")
-            sys.exit()
-        f(args)
-    return new_f
+    def arg_catcher(*args):
+        def new_f():
+            if sys.platfom == "win32":
+                Console.error("The method {f.__name__} is not implemented in Windows,"
+                            " please implement, and/or submit an issue.")
+                sys.exit()
+            f(args)
+        return new_f
+    return arg_catcher
 
 
 
@@ -234,8 +236,8 @@ class Shell(object):
         else:
             os.system("python -m webbrowser -t {file}".format(**data))
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def terminal(cls, command='pwd'):
 
         if platform == 'darwin':
@@ -335,8 +337,8 @@ class Shell(object):
         """
         return subprocess.check_output(*args, **kwargs)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def ls(cls, *args):
         """
         executes ls with the given arguments
@@ -346,8 +348,8 @@ class Shell(object):
         # TODO: replace with glob
         return cls.execute('ls', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def ps(cls, *args):
         """
         executes ps with the given arguments
@@ -367,8 +369,8 @@ class Shell(object):
         """
         return cls.execute('bash', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def brew(cls, *args):
         """
         executes bash with the given arguments
@@ -377,8 +379,8 @@ class Shell(object):
         """
         return cls.execute('brew', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def cat(cls, *args):
         """
         executes cat with the given arguments
@@ -450,8 +452,8 @@ class Shell(object):
         """
         return cls.execute('cmsd', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def head(cls, *args):
         """
         executes head with the given arguments
@@ -470,8 +472,8 @@ class Shell(object):
         """
         return cls.execute('keystone', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def kill(cls, *args):
         """
         executes kill with the given arguments
@@ -504,8 +506,8 @@ class Shell(object):
                                                             count=count,
                                                             host=host))
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def pwd(cls, *args):
         """
         executes pwd with the given arguments
@@ -525,8 +527,8 @@ class Shell(object):
         """
         return cls.execute('rackdiag', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def rm(cls, *args):
         """
         executes rm with the given arguments
@@ -554,8 +556,8 @@ class Shell(object):
         """
         return cls.execute('scp', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def sort(cls, *args):
         """
         executes sort with the given arguments
@@ -583,8 +585,8 @@ class Shell(object):
         """
         return cls.execute('ssh', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def sudo(cls, *args):
         """
         executes sudo with the given arguments
@@ -594,8 +596,8 @@ class Shell(object):
         # TODO: https://stackoverflow.com/questions/9652720/how-to-run-sudo-command-in-windows
         return cls.execute('sudo', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def tail(cls, *args):
         """
         executes tail with the given arguments
@@ -632,8 +634,8 @@ class Shell(object):
         """
         return cls.execute('mongod', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def dialog(cls, *args):
         """
         executes dialof with the given arguments
@@ -651,8 +653,8 @@ class Shell(object):
         """
         return cls.execute('pip', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def fgrep(cls, *args):
         """
         executes fgrep with the given arguments
@@ -662,8 +664,8 @@ class Shell(object):
         # TODO: see cm_grep
         return cls.execute('fgrep', args)
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def grep(cls, *args):
         """
         executes grep with the given arguments
@@ -959,8 +961,8 @@ class Shell(object):
         else:
            raise NotImplementedError("Editor not configured for OS")
 
-    @NotImplementedInWindows
     @classmethod
+    @NotImplementedInWindows
     def lsb_release(cls):
         """
         executes lsb_release command


### PR DESCRIPTION
The Windows decorator was incapable of decorating functions that accepted arguments. 
This would lead to errors in testing the 1_local/test_shell.py file when it would test the shell.ls("-la") command. 
The decorator would decorate the function and return the address of new_f, but new_f takes no positional arguments. 
Thus wrapping new_f with a function that takes any number of arguments follows the intent of the function, since they were being discarded 