### PR TITLE
Reenable automated Windows pytest and fix base, flatdict, and Shell functions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -78,14 +78,14 @@ jobs:
       run: |
         python -m venv ENV3
 
-    # - name: Lint with flake8
-    #   run: |
-    #     .\ENV3\Scripts\activate.ps1
-    #     pip install flake8
-    #     # stop the build if there are Python syntax errors or undefined names
-    #     flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
-    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-    #     flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with flake8
+      run: |
+        .\ENV3\Scripts\activate.ps1
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Install current Python library
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -46,54 +46,54 @@ jobs:
         source activate base & pytest tests -rsx
 
 
-#  build-windows:
-#    runs-on: windows-latest
-#    strategy:
-#      max-parallel: 5
-#
-#    steps:
-#    # - uses: actions/checkout@v3
-#    # - name: Set up Python 3.10
-#    #   uses: conda-incubator/setup-miniconda@v2
-#    #   with:
-#    #     miniconda-version: "latest"
-#    - uses: actions/checkout@v3
-#    - name: Set up Python 3.12
-#      uses: actions/setup-python@v3
-#      with:
-#        python-version: '3.12'
-#    # - name: Add conda to system path
-#    #   run: |
-#    #     # $CONDA is an environment variable pointing to the root of the miniconda directory
-#    #     echo $CONDA/bin >> $GITHUB_PATH
-#    # - name: Add extra channels
-#    #   run: |
-#    #     conda config --add channels conda-forge
-#    #     conda config --add channels defaults
-#
-#    # - name: Install dependencies
-#    #   run: |
-#    #     conda env update --file environment.yml --name base
-#    - name: set up env3
-#      run: |
-#        python -m venv ENV3
-#
-#    - name: Lint with flake8
-#      run: |
-#        .\ENV3\Scripts\activate.ps1
-#        pip install flake8
-#        # stop the build if there are Python syntax errors or undefined names
-#        flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
-#        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-#        flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-#
-#    - name: Install current Python library
-#      run: |
-#        .\ENV3\Scripts\activate.ps1
-#        pip install -e .     # Install the current Python library in editable mode
-#        pip install cloudmesh-vpn
-#    - name: Test with pytest
-#      run: |
-#        .\ENV3\Scripts\activate.ps1
-#        pip install pytest
-#        pytest tests -rsx
+ build-windows:
+   runs-on: windows-latest
+   strategy:
+     max-parallel: 5
+
+   steps:
+   # - uses: actions/checkout@v3
+   # - name: Set up Python 3.10
+   #   uses: conda-incubator/setup-miniconda@v2
+   #   with:
+   #     miniconda-version: "latest"
+   - uses: actions/checkout@v3
+   - name: Set up Python 3.12
+     uses: actions/setup-python@v3
+     with:
+       python-version: '3.12'
+   # - name: Add conda to system path
+   #   run: |
+   #     # $CONDA is an environment variable pointing to the root of the miniconda directory
+   #     echo $CONDA/bin >> $GITHUB_PATH
+   # - name: Add extra channels
+   #   run: |
+   #     conda config --add channels conda-forge
+   #     conda config --add channels defaults
+
+   # - name: Install dependencies
+   #   run: |
+   #     conda env update --file environment.yml --name base
+   - name: set up env3
+     run: |
+       python -m venv ENV3
+
+   - name: Lint with flake8
+     run: |
+       .\ENV3\Scripts\activate.ps1
+       pip install flake8
+       # stop the build if there are Python syntax errors or undefined names
+       flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
+       # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+       flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+   - name: Install current Python library
+     run: |
+       .\ENV3\Scripts\activate.ps1
+       pip install -e .     # Install the current Python library in editable mode
+       pip install cloudmesh-vpn
+   - name: Test with pytest
+     run: |
+       .\ENV3\Scripts\activate.ps1
+       pip install pytest
+       pytest tests -rsx

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -78,14 +78,14 @@ jobs:
       run: |
         python -m venv ENV3
 
-    - name: Lint with flake8
-      run: |
-        .\ENV3\Scripts\activate.ps1
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    # - name: Lint with flake8
+    #   run: |
+    #     .\ENV3\Scripts\activate.ps1
+    #     pip install flake8
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Install current Python library
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -46,54 +46,54 @@ jobs:
         source activate base & pytest tests -rsx
 
 
- build-windows:
-   runs-on: windows-latest
-   strategy:
-     max-parallel: 5
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 5
 
-   steps:
-   # - uses: actions/checkout@v3
-   # - name: Set up Python 3.10
-   #   uses: conda-incubator/setup-miniconda@v2
-   #   with:
-   #     miniconda-version: "latest"
-   - uses: actions/checkout@v3
-   - name: Set up Python 3.12
-     uses: actions/setup-python@v3
-     with:
-       python-version: '3.12'
-   # - name: Add conda to system path
-   #   run: |
-   #     # $CONDA is an environment variable pointing to the root of the miniconda directory
-   #     echo $CONDA/bin >> $GITHUB_PATH
-   # - name: Add extra channels
-   #   run: |
-   #     conda config --add channels conda-forge
-   #     conda config --add channels defaults
+    steps:
+    # - uses: actions/checkout@v3
+    # - name: Set up Python 3.10
+    #   uses: conda-incubator/setup-miniconda@v2
+    #   with:
+    #     miniconda-version: "latest"
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.12'
+    # - name: Add conda to system path
+    #   run: |
+    #     # $CONDA is an environment variable pointing to the root of the miniconda directory
+    #     echo $CONDA/bin >> $GITHUB_PATH
+    # - name: Add extra channels
+    #   run: |
+    #     conda config --add channels conda-forge
+    #     conda config --add channels defaults
 
-   # - name: Install dependencies
-   #   run: |
-   #     conda env update --file environment.yml --name base
-   - name: set up env3
-     run: |
-       python -m venv ENV3
+    # - name: Install dependencies
+    #   run: |
+    #     conda env update --file environment.yml --name base
+    - name: set up env3
+      run: |
+        python -m venv ENV3
 
-   - name: Lint with flake8
-     run: |
-       .\ENV3\Scripts\activate.ps1
-       pip install flake8
-       # stop the build if there are Python syntax errors or undefined names
-       flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
-       # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-       flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with flake8
+      run: |
+        .\ENV3\Scripts\activate.ps1
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 --exclude deprecated . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 --exclude deprecated . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-   - name: Install current Python library
-     run: |
-       .\ENV3\Scripts\activate.ps1
-       pip install -e .     # Install the current Python library in editable mode
-       pip install cloudmesh-vpn
-   - name: Test with pytest
-     run: |
-       .\ENV3\Scripts\activate.ps1
-       pip install pytest
-       pytest tests -rsx
+    - name: Install current Python library
+      run: |
+        .\ENV3\Scripts\activate.ps1
+        pip install -e .     # Install the current Python library in editable mode
+        pip install cloudmesh-vpn
+    - name: Test with pytest
+      run: |
+        .\ENV3\Scripts\activate.ps1
+        pip install pytest
+        pytest tests -rsx

--- a/src/cloudmesh/common/Shell.py
+++ b/src/cloudmesh/common/Shell.py
@@ -1165,6 +1165,10 @@ class Shell(object):
         """
         found = []
         for proc in psutil.process_iter():
+            if proc.name() == "WUDFHost.exe":
+                # Windows fatal exception: access violation
+                continue
+        
             try:
                 if attributes is not None:
                     pinfo = proc.as_dict(attrs=attributes)
@@ -1185,7 +1189,7 @@ class Shell(object):
                     )
                 else:
                     pinfo = proc.as_dict()
-            except psutil.NoSuchProcess:
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 pass
             else:
                 found.append(pinfo)

--- a/src/cloudmesh/common/base.py
+++ b/src/cloudmesh/common/base.py
@@ -43,7 +43,9 @@ class Base:
         # Expand the tilde (~) to the user's home directory path
         self.path = os.path.expanduser(self.path)
 
-        self.config = os.path.join(self.path, "cloudmesh.yaml")
+        self.path = os.path.normpath(self.path)
+
+        self.config = os.path.normpath(os.path.join(self.path, "cloudmesh.yaml"))
         if create:
             self.create()
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -20,16 +20,17 @@ class Test_Base:
         HEADING()
         cloudmesh = Base()
         expected_path = os.path.expanduser("~/.cloudmesh")
+        expected_path = os.path.normpath(expected_path)
         assert cloudmesh.path == expected_path
-        assert cloudmesh.config == f"{expected_path}/cloudmesh.yaml"
+        assert cloudmesh.config == os.path.normpath(f"{expected_path}/cloudmesh.yaml")
 
     def test_custom_path(self):
         HEADING()
-        custom_path = "./tmp/.cloudmesh"
+        custom_path = os.path.normpath("./tmp/.cloudmesh")
         cloudmesh = Base(path=custom_path)
         assert cloudmesh.path == custom_path
-        assert cloudmesh.config == f"{custom_path}/cloudmesh.yaml"
-        shutil.rmtree("./tmp")
+        assert cloudmesh.config == os.path.normpath(f"{custom_path}/cloudmesh.yaml")
+        shutil.rmtree(os.path.normpath("./tmp"))
 
     def test_environment_variable_path(self):
         HEADING()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -19,25 +19,25 @@ class Test_Base:
     def test_default_path_in_home(self):
         HEADING()
         cloudmesh = Base()
-        expected_path = os.path.expanduser("~/.cloudmesh")
-        expected_path = os.path.normpath(expected_path)
+        expected_path = os.path.normpath(os.path.expanduser("~/.cloudmesh"))
+
         assert cloudmesh.path == expected_path
-        assert cloudmesh.config == os.path.normpath(f"{expected_path}/cloudmesh.yaml")
+        assert cloudmesh.config == f"{expected_path}/cloudmesh.yaml" if os.name != "nt" else fr"{expected_path}\cloudmesh.yaml"
 
     def test_custom_path(self):
         HEADING()
-        custom_path = os.path.normpath("./tmp/.cloudmesh")
+        custom_path = "./tmp/.cloudmesh" if os.name != "nt" else r"tmp\.cloudmesh"
         cloudmesh = Base(path=custom_path)
         assert cloudmesh.path == custom_path
-        assert cloudmesh.config == os.path.normpath(f"{custom_path}/cloudmesh.yaml")
-        shutil.rmtree(os.path.normpath("./tmp"))
+        assert cloudmesh.config == f"{custom_path}/cloudmesh.yaml" if os.name != "nt" else fr"{custom_path}\cloudmesh.yaml"
+        shutil.rmtree("./tmp")
 
     def test_environment_variable_path(self):
         HEADING()
         os.environ["CLOUDMESH_CONFIG_DIR"] = "./tmp/.cloudmesh"
         cloudmesh = Base()
-        assert cloudmesh.path == "./tmp/.cloudmesh"
-        assert cloudmesh.config == f"{cloudmesh.path}/cloudmesh.yaml"
+        assert cloudmesh.path == "./tmp/.cloudmesh" if os.name != "nt" else r"tmp\.cloudmesh"
+        assert cloudmesh.config == f"{cloudmesh.path}/cloudmesh.yaml" if os.name != "nt" else fr"{cloudmesh.path}\cloudmesh.yaml"
         shutil.rmtree("./tmp")
         del os.environ["CLOUDMESH_CONFIG_DIR"]
 
@@ -52,6 +52,6 @@ class Test_Base:
         cloudmesh = Base()
         print(cloudmesh.path)
         assert cloudmesh.path == ".cloudmesh"
-        assert cloudmesh.config == ".cloudmesh/cloudmesh.yaml"
+        assert cloudmesh.config == ".cloudmesh/cloudmesh.yaml" if os.name != "nt" else r".cloudmesh\cloudmesh.yaml"
         os.chdir(cwd)
         shutil.rmtree("/tmp/test")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -26,17 +26,17 @@ class Test_Base:
 
     def test_custom_path(self):
         HEADING()
-        custom_path = "./tmp/.cloudmesh" if os.name != "nt" else r"tmp\.cloudmesh"
+        custom_path = "tmp/.cloudmesh" if os.name != "nt" else r"tmp\.cloudmesh"
         cloudmesh = Base(path=custom_path)
         assert cloudmesh.path == custom_path
         assert cloudmesh.config == f"{custom_path}/cloudmesh.yaml" if os.name != "nt" else fr"{custom_path}\cloudmesh.yaml"
         shutil.rmtree("./tmp")
 
-    def test_environment_variable_path(self):
+    def test_environment_variable_path(self, monkeypatch):
         HEADING()
-        os.environ["CLOUDMESH_CONFIG_DIR"] = "./tmp/.cloudmesh"
+        monkeypatch.setenv("CLOUDMESH_CONFIG_DIR", "./tmp/.cloudmesh")
         cloudmesh = Base()
-        assert cloudmesh.path == "./tmp/.cloudmesh" if os.name != "nt" else r"tmp\.cloudmesh"
+        assert cloudmesh.path == "tmp/.cloudmesh" if os.name != "nt" else r"tmp\.cloudmesh"
         assert cloudmesh.config == f"{cloudmesh.path}/cloudmesh.yaml" if os.name != "nt" else fr"{cloudmesh.path}\cloudmesh.yaml"
         shutil.rmtree("./tmp")
         del os.environ["CLOUDMESH_CONFIG_DIR"]

--- a/tests/test_flatdict.py
+++ b/tests/test_flatdict.py
@@ -214,7 +214,7 @@ class Test_Flatdict:
         HEADING()
 
         config = FlatDict(expand=["os.", "cm.", "cloudmesh."])
-        config .load("tests/config.in.yaml")
+        config.loadf("tests/config.in.yaml")
 
         print("config:")
         pprint(dict(config))

--- a/tests/test_shell_tests.py
+++ b/tests/test_shell_tests.py
@@ -14,6 +14,7 @@ OS we have on the team.
 import os
 import os.path
 from pathlib import Path
+import getpass
 
 import pytest
 from cloudmesh.common.Benchmark import Benchmark
@@ -61,7 +62,7 @@ class TestShell:
     def test_map_filename(self):
         HEADING()
         Benchmark.Start()
-        user = os.path.basename(os.environ["HOME"])
+        user = getpass.getuser()
         if os_is_windows():
             pwd = os.getcwd().replace("C:","/mnt/c").replace("\\","/")
         else:
@@ -107,7 +108,7 @@ class TestShell:
             else:
                 assert result.path == f'C:\\home\\{user}\\cm'
         else:
-            assert result.path == f'C:\\Users\\{user}\\cm'
+            assert result.path == f'{Path.home()}\\cm'
 
         result = Shell.map_filename(name='scp:user@host:~/cm')
         assert result.user == "user"


### PR DESCRIPTION
The following PR fixes and reenables Windows pytests, with all tests passing due to making adjustments to cloudmesh common functions. Some idiosyncracies such as restricted processes in Windows are identified and mitigated.

Also, there was a pressing issue with pytest environment variables.
Deleting/unsetting environment variables is not possible with `del` and the solution is to use `monkeypatch` which is included in pytest. Now, `Test_Base` passes on WSL.