### PR TITLE
Improve slow Shell.live printing

### DIFF
--- a/src/cloudmesh/common/Shell.py
+++ b/src/cloudmesh/common/Shell.py
@@ -1044,18 +1044,16 @@ class Shell(object):
         process = subprocess.Popen(
             shlex.split(command), cwd=cwd, stdout=subprocess.PIPE
         )
-        result = b""
-        while True:
-            output = process.stdout.read(1)
-            if output == b"" and process.poll() is not None:
-                break
-            if output:
-                result = result + output
-                sys.stdout.write(output.decode("utf-8"))
-                sys.stdout.flush()
-        rc = process.poll()
-        data = dotdict({"status": rc, "text": output.decode("utf-8")})
-        return data
+        
+        output_lines = []
+        for line in iter(process.stdout.readline, b''):
+            sys.stdout.write(line.decode("utf-8"))
+            sys.stdout.flush()
+            output_lines.append(line)
+        
+        rc = process.wait()
+        full_output = b"".join(output_lines).decode("utf-8")
+        return dotdict({"status": rc, "text": full_output})
 
     @staticmethod
     def calculate_disk_space(directory):


### PR DESCRIPTION
In testing, I found that the Shell class's live method caused an unreasonable slowdown in the command execution. The culprit seems to be 

- Use of while loop instead of iterator
- Constant concatenation of strings
- Reading and printing every character

To benchmark to see how these changes improved efficiency, I created this bash script to simulate an cli-intensive program:
```bash
#!/bin/bash
# intensive.sh: Print 100,000 lines to simulate heavy output

for i in {1..100000}; do
    echo "Line $i: This is an intensive print test."
done
```

And the following python script:
```py
from cloudmesh.common.Shell import Shell
from cloudmesh.common.StopWatch import StopWatch

shell = Shell()

# Start benchmarking the live execution
StopWatch.start("benchmark")
# Execute the intensive bash script; its output will be printed live
r = shell.live('./intensive.sh')
StopWatch.stop("benchmark")

# Print benchmark results
StopWatch.benchmark()

# Print the final result from the command execution (status and full output)
print(r)
```

Old time to completion: 546.874s
New time to completion: 0.585s

In this case, I observed a nearly 1000x speedup in performance, and found that the performance was identical to `subprocess.call("./intensive.sh")`.